### PR TITLE
fix to hide scrollbars on the game

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -31,6 +31,8 @@ html {
   font-family: $font-family;
   max-width: $page-width;
   margin: 0 auto;
+  overflow-x: hidden;
+  overflow-y: hidden;
   text-align: center;
 }
 
@@ -160,8 +162,4 @@ video {
 
 .modal-content {
   border-radius: 5px;
-}
-
-html{
-  overflow: hidden;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -161,3 +161,10 @@ video {
 .modal-content {
   border-radius: 5px;
 }
+
+// hide scrollbars
+::-webkit-scrollbar-track, ::-webkit-scrollbar, ::-webkit-scrollbar-thumb  {
+  border: 0px;
+  width: 0px;
+  padding: 0px;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -162,6 +162,6 @@ video {
   border-radius: 5px;
 }
 
-*{
-  overflow: hidden !important
+html{
+  overflow: hidden;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -162,9 +162,6 @@ video {
   border-radius: 5px;
 }
 
-// hide scrollbars
-::-webkit-scrollbar-track, ::-webkit-scrollbar, ::-webkit-scrollbar-thumb  {
-  border: 0px;
-  width: 0px;
-  padding: 0px;
+*{
+  overflow: hidden !important
 }


### PR DESCRIPTION
Remove the unnecessary scrollbars on the game, they seem to be caused the scss module, so I have opted to simply use !important, which I know is bad practice, but meddling with the scss module files seems like that would be even worse, especially as this uses an older version of node.